### PR TITLE
Add support for ES modules and (0.15.0)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,3 @@
-# Verison v0.3.2
+# Version v0.3.2
 - Copy foreign modules from source directories if they are not present in the
   `output` directory.

--- a/app/Command/Run.hs
+++ b/app/Command/Run.hs
@@ -267,11 +267,11 @@ dceCommand Options { optEntryPoints
                     -- run `runForeignModuleDeadCodeElimination`
                     Just path | optForeign  -> do
                       jsCode <- BSL.Char8.unpack <$> BSL.readFile path
-                      case JS.parse jsCode path of
+                      case JS.parseModule jsCode path of
                         Left _ -> return ()
-                        Right (JS.JSAstProgram ss ann) ->
-                          let ss'    = DCE.runForeignModuleDeadCodeElimination moduleForeign ss
-                              jsAst' = JS.JSAstProgram ss' ann
+                        Right (JS.JSAstModule items ann) ->
+                          let items'    = DCE.runForeignModuleDeadCodeElimination moduleForeign items
+                              jsAst' = JS.JSAstModule items' ann
                               foreignFile = optOutputDir
                                         </> T.unpack (P.runModuleName moduleName)
                                         </> "foreign.js"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,8 +6,8 @@ import qualified Paths_zephyr as Paths
 import           System.Environment (getArgs)
 import qualified System.IO as IO
 
-import           Command.Run
-import           Command.Options
+import Command.Run ( runZephyr )
+import Command.Options ( parseOptions )
 
 
 main :: IO ()
@@ -21,8 +21,8 @@ main = do
     >>= runZephyr
   where
     execParserPure :: Opts.ParserInfo a -> [String] -> Opts.ParserResult a
-    execParserPure pinfo [] = Opts.Failure $
-      Opts.parserFailure Opts.defaultPrefs pinfo Opts.ShowHelpText mempty
+    execParserPure pinfo [] = Opts.Failure $ 
+      Opts.parserFailure Opts.defaultPrefs pinfo (Opts.ShowHelpText Nothing) mempty
     execParserPure pinfo args = Opts.execParserPure Opts.defaultPrefs pinfo args
 
 versionOpt :: Opts.Parser (a -> a)

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,11 @@
 index-state: 2021-11-25T21:23:01Z
 packages: .
+source-repository-package
+  type: git
+  location: https://github.com/working-group-purescript-es/purescript.git
+  tag: 593230b9d6f53790f25d5d9a93142dca942b8387
+source-repository-package
+  type: git
+  location: https://github.com/working-group-purescript-es/purescript.git
+  tag: 593230b9d6f53790f25d5d9a93142dca942b8387
+  subdir: lib/purescript-cst

--- a/src/Language/PureScript/DCE.hs
+++ b/src/Language/PureScript/DCE.hs
@@ -2,6 +2,20 @@ module Language.PureScript.DCE
   ( module DCE ) where
 
 import Language.PureScript.DCE.CoreFn as DCE
+    ( runDeadCodeElimination, runBindDeadCodeElimination )
 import Language.PureScript.DCE.Foreign as DCE
+    ( runForeignModuleDeadCodeElimination )
 import Language.PureScript.DCE.Errors as DCE
-import Language.PureScript.DCE.Eval as DCE
+    ( Level(..),
+      DCEError(..),
+      EntryPoint(..),
+      isEntryParseError,
+      showEntryPoint,
+      displayDCEError,
+      displayDCEWarning,
+      errorColor,
+      warnColor,
+      codeColor,
+      colorString,
+      colorText )
+import Language.PureScript.DCE.Eval as DCE ( evaluate )

--- a/src/Language/PureScript/DCE/CoreFn.hs
+++ b/src/Language/PureScript/DCE/CoreFn.hs
@@ -11,6 +11,7 @@ import Control.Monad ( guard )
 import Data.Graph ( graphFromEdges, reachable, Vertex )
 import           Data.Foldable (foldl', foldr')
 import           Data.List (groupBy, sortBy)
+import qualified Data.Map.Strict as M
 import           Data.Maybe (catMaybes, mapMaybe)
 import qualified Data.Set as S
 import Language.PureScript.CoreFn
@@ -22,7 +23,7 @@ import Language.PureScript.CoreFn
       CaseAlternative(CaseAlternative),
       Expr(..),
       Module(Module, moduleImports, moduleExports, moduleForeign,
-             moduleDecls, moduleName) )
+             moduleDecls, moduleName, moduleReExports) )
 import           Language.PureScript.DCE.Utils (bindIdents, unBind)
 import Language.PureScript.Names
     ( getQual,
@@ -39,6 +40,8 @@ type Key = Qualified Ident
 data DCEVertex
   = BindVertex (Bind Ann)
   | ForeignVertex (Qualified Ident)
+  | ReExportedVertex (Qualified Ident)
+  deriving (Show)
 
 
 -- | Dead code elimination of a list of modules module
@@ -61,6 +64,7 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
       -> Module Ann
     runModuleDeadCodeElimination vs mod@Module{ moduleDecls
                         , moduleExports
+                        , moduleReExports
                         , moduleImports
                         , moduleName
                         , moduleForeign
@@ -87,6 +91,17 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
           moduleExports' =
             filter (`elem` (idents ++ moduleForeign')) moduleExports
 
+          moduleReExports' :: M.Map ModuleName [Ident]
+          moduleReExports' =
+            filter (`elem` rexpIdents) <$> moduleReExports
+            where
+              toRexpIdents :: (DCEVertex, Key, [Key]) -> [Ident]
+              toRexpIdents (ReExportedVertex (Qualified _ i), _, _) = [i]
+              toRexpIdents _ = []
+
+              rexpIdents :: [Ident]
+              rexpIdents = concatMap toRexpIdents vs
+
           mods :: [ModuleName]
           mods = mapMaybe getQual (concatMap (\(_, _, ks) -> ks) vs)
 
@@ -104,6 +119,7 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
 
       in mod { moduleImports = moduleImports'
              , moduleExports = moduleExports'
+             , moduleReExports = moduleReExports'
              , moduleForeign = moduleForeign'
              , moduleDecls   = moduleDecls'
              }
@@ -113,9 +129,10 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
     -- | The Vertex set.
     verts :: [(DCEVertex, Key, [Key])]
     verts = do
-        Module _ _ mn _ _ _ _ mf ds <- modules
-        concatMap (toVertices mn) ds
-          ++ ((\q -> (ForeignVertex q, q, [])) . flip mkQualified mn) `map` mf
+        Module _ _ mn _ _ _ rexp mf ds <- modules
+        concatMap (toVertices mn) ds -- Module local bindings
+          ++ ((\q -> (ForeignVertex q, q, [])) . flip mkQualified mn) `map` mf -- Foreign bindings
+          ++ reExportedVertices mn rexp -- Re-exported bindings
       where
       toVertices :: ModuleName -> Bind Ann -> [(DCEVertex, Key, [Key])]
       toVertices mn b@(NonRec _ i e) =
@@ -124,6 +141,23 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
         let ks :: [(Key, [Key])]
             ks = map (\((_, i), e) -> (mkQualified i mn, deps e)) bs
         in map (\(k, ks') -> (BindVertex b, k, map fst ks ++ ks')) ks
+
+      reExportedVertices :: ModuleName -> M.Map ModuleName [Ident] -> [(DCEVertex, Key, [Key])]
+      reExportedVertices parent rexp =
+        filter (isReExported rexp) modules >>= rexpsFor
+        where
+          rexpsFor :: Module Ann -> [(DCEVertex, Key, [Key])]
+          rexpsFor (Module _ _ mn _ _ _ _ _ _) = case M.lookup mn rexp of
+            Nothing -> []
+            Just ids -> (\i -> (ReExportedVertex (mkQualified i parent)
+                              , mkQualified i parent
+                              , [mkQualified i mn])
+                       ) <$> ids
+
+
+      isReExported :: M.Map ModuleName [Ident] -> Module Ann -> Bool
+      isReExported rexps (Module _ _ name _ _ _ _ _ _) =
+        M.member name rexps
 
       -- | Find dependencies of an expression.
       deps :: Expr Ann -> [Key]

--- a/src/Language/PureScript/DCE/Foreign.hs
+++ b/src/Language/PureScript/DCE/Foreign.hs
@@ -7,8 +7,8 @@ module Language.PureScript.DCE.Foreign
   ) where
 
 import           Prelude.Compat
-import           Control.Monad
-import           Data.Graph
+import Control.Monad ( guard )
+import Data.Graph ( graphFromEdges, path, Vertex )
 import           Data.Foldable (foldr')
 import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import           Data.Text (Text)
@@ -28,9 +28,9 @@ import           Language.JavaScript.Parser.AST
                   , JSMethodDefinition(..)
                   , JSClassElement(..)
                   , JSClassHeritage(..)
-                  , JSTemplatePart(..)
+                  , JSTemplatePart(..), JSModuleItem (JSModuleStatementListItem)
                   )
-import           Language.PureScript.Names
+import Language.PureScript.Names ( runIdent, Ident )
 
 -- | foldr over `JSCommaList`
 foldrJSCommaList :: (a -> b -> b) -> JSCommaList a -> b -> b
@@ -42,44 +42,44 @@ foldrJSCommaList fn (JSLCons as _ a) !b = foldrJSCommaList fn as (fn a b)
 -- might remove declarations that are used somewhere in the foreign module (for
 -- example by using @'eval'@).
 --
-runForeignModuleDeadCodeElimination :: [Ident] -> [JSStatement] -> [JSStatement]
-runForeignModuleDeadCodeElimination is stmts = filter filterExports stmts
+runForeignModuleDeadCodeElimination :: [Ident] -> [JSModuleItem] -> [JSModuleItem]
+runForeignModuleDeadCodeElimination is items = filter filterExports items
   where
-    filterExports :: JSStatement -> Bool
-    filterExports (JSAssignStatement (JSMemberSquare (JSIdentifier _ "exports") _ (JSStringLiteral _ x) _) _ _ _)
+    filterExports :: JSModuleItem -> Bool
+    filterExports (JSModuleStatementListItem (JSAssignStatement (JSMemberSquare (JSIdentifier _ "exports") _ (JSStringLiteral _ x) _) _ _ _))
       = fltr (unquote . T.pack $ x)
-    filterExports (JSAssignStatement (JSMemberDot (JSIdentifier _ "exports") _ (JSIdentifier _ x)) _ _ _)
+    filterExports (JSModuleStatementListItem (JSAssignStatement (JSMemberDot (JSIdentifier _ "exports") _ (JSIdentifier _ x)) _ _ _))
       = fltr (T.pack x)
     filterExports _ = True
 
     fltr :: Text -> Bool
     fltr t = any (fromMaybe True . (path graph <$> vertexForKey t <*>) . Just) entryPointVertices
           -- one of `entryPointVertices` depend on this vertex
-          || any (isUsedInStmt t) nonExps
+          || any (isUsedInItem t) nonExps
           -- it is used in any non export statements
 
     -- Build a graph of exports statements.  Its initial set of edges point from
     -- an export statement to all other export statements that are using it.
     -- When checking if we need to include that vartex we just check if there is
     -- a path from a vertex to one of `entryPointVertices`.
-    exps :: [JSStatement]
-    exps = filter isExportStatement stmts
+    exps :: [JSModuleItem]
+    exps = filter isExportStatement items
 
-    nonExps = filter (not . isExportStatement) stmts
+    nonExps = filter (not . isExportStatement) items
 
     (graph, _, vertexForKey) = graphFromEdges verts
 
-    verts :: [(JSStatement, Text, [Text])]
+    verts :: [(JSModuleItem, Text, [Text])]
     verts = mapMaybe toVert exps
       where
-      toVert :: JSStatement -> Maybe (JSStatement, Text, [Text])
-      toVert s
-        | Just name <- exportStatementName s = Just (s, name, foldr' (fn name) [] exps)
+      toVert :: JSModuleItem -> Maybe (JSModuleItem, Text, [Text])
+      toVert item
+        | Just name <- exportStatementName item = Just (item, name, foldr' (fn name) [] exps)
         | otherwise = Nothing
 
-      fn name s' nms
-        | isUsedInStmt name s'
-        , Just n <- exportStatementName s' = n:nms
+      fn name item' nms
+        | isUsedInItem name item'
+        , Just n <- exportStatementName item' = n:nms
         | otherwise = nms
 
     entryPointVertices :: [Vertex]
@@ -93,15 +93,19 @@ runForeignModuleDeadCodeElimination is stmts = filter filterExports stmts
     unquote :: Text -> Text
     unquote = T.drop 1 . T.dropEnd 1
 
-    isExportStatement :: JSStatement -> Bool
-    isExportStatement (JSAssignStatement (JSMemberDot (JSIdentifier _ "exports") _ (JSIdentifier _ _)) _ _ _) = True
-    isExportStatement (JSAssignStatement (JSMemberSquare (JSIdentifier _ "exports") _ (JSStringLiteral _ _) _) _ _ _) = True
+    isExportStatement :: JSModuleItem -> Bool
+    isExportStatement (JSModuleStatementListItem (JSAssignStatement (JSMemberDot (JSIdentifier _ "exports") _ (JSIdentifier _ _)) _ _ _)) = True
+    isExportStatement (JSModuleStatementListItem (JSAssignStatement (JSMemberSquare (JSIdentifier _ "exports") _ (JSStringLiteral _ _) _) _ _ _)) = True
     isExportStatement _ = False
 
-    exportStatementName :: JSStatement -> Maybe Text
-    exportStatementName (JSAssignStatement (JSMemberDot (JSIdentifier _ "exports") _ (JSIdentifier _ i)) _ _ _) = Just . T.pack $ i
-    exportStatementName (JSAssignStatement (JSMemberSquare (JSIdentifier _ "exports") _ (JSStringLiteral _ i) _) _ _ _) = Just . unquote . T.pack $ i
+    exportStatementName :: JSModuleItem -> Maybe Text
+    exportStatementName (JSModuleStatementListItem (JSAssignStatement (JSMemberDot (JSIdentifier _ "exports") _ (JSIdentifier _ i)) _ _ _)) = Just . T.pack $ i
+    exportStatementName (JSModuleStatementListItem (JSAssignStatement (JSMemberSquare (JSIdentifier _ "exports") _ (JSStringLiteral _ i) _) _ _ _)) = Just . unquote . T.pack $ i
     exportStatementName _ = Nothing
+
+    isUsedInItem :: Text -> JSModuleItem -> Bool
+    isUsedInItem n (JSModuleStatementListItem stmt) = isUsedInStmt n stmt
+    isUsedInItem _ _ = False
 
     -- Check if (export) identifier is used within a JSStatement.
     isUsedInStmt :: Text -> JSStatement -> Bool
@@ -146,7 +150,7 @@ runForeignModuleDeadCodeElimination is stmts = filter filterExports stmts
     isUsedInStmt n (JSExpressionStatement e _) = isUsedInExpr n e
     isUsedInStmt n (JSAssignStatement e1 _ e2 _) = isUsedInExpr n e1 || isUsedInExpr n e2
     isUsedInStmt n (JSMethodCall e _ es _ _) = isUsedInExpr n e || isUsedInExprs n es
-    isUsedInStmt n (JSReturn _ me _) = fromMaybe False (isUsedInExpr n <$> me)
+    isUsedInStmt n (JSReturn _ me _) = maybe False (isUsedInExpr n) me
     isUsedInStmt n (JSSwitch _ _ e _ _ sps _ _) = isUsedInExpr n e || any (isUsedInSwitchParts n) sps
     isUsedInStmt n (JSThrow _ e _) = isUsedInExpr n e
     isUsedInStmt n (JSTry _ (JSBlock _ ss _) cs f) = any (isUsedInStmt n) ss || any (isUsedInTryCatch n) cs || isUsedInFinally n f

--- a/test/Test/Lib.hs
+++ b/test/Test/Lib.hs
@@ -69,6 +69,10 @@ libTests =
             Nothing
             "literals-fromanobject.js"
             True
+  , LibTest ["Control.Alt.map"]
+            Nothing
+            "use-reexports.js"
+            True
   ]
 
 

--- a/test/lib-tests/eval-evalunderarrayliteral.js
+++ b/test/lib-tests/eval-evalunderarrayliteral.js
@@ -1,0 +1,1 @@
+import { evalUnderArrayLiteral } from "./dce-output/Eval/index.js";

--- a/test/lib-tests/eval-evalunderobjectliteral.js
+++ b/test/lib-tests/eval-evalunderobjectliteral.js
@@ -1,0 +1,1 @@
+import { evalUnderObjectLiteral } from "./dce-output/Eval/index.js";

--- a/test/lib-tests/eval-makeappqueue.js
+++ b/test/lib-tests/eval-makeappqueue.js
@@ -1,0 +1,1 @@
+import { makeAppQueue } from "./dce-output/Eval/index.js";

--- a/test/lib-tests/eval-recordupdate.js
+++ b/test/lib-tests/eval-recordupdate.js
@@ -1,0 +1,6 @@
+import * as E from "./dce-output/Eval/index.js";
+var foo = E.recordUpdate({ foo: "", bar: 0 })(E.Foo.create("foo"));
+if (foo.foo != "foo") {
+  console.error(foo);
+  throw "Error";
+}

--- a/test/lib-tests/eval.js
+++ b/test/lib-tests/eval.js
@@ -1,0 +1,1 @@
+import { evalVars } from "./dce-output/Eval/index.js";

--- a/test/lib-tests/foreign-test-add.js
+++ b/test/lib-tests/foreign-test-add.js
@@ -1,0 +1,2 @@
+import { add } from "./dce-output/Foreign.Test/index.js";
+add(1)(1);

--- a/test/lib-tests/foreign-test-mult.js
+++ b/test/lib-tests/foreign-test-mult.js
@@ -1,0 +1,2 @@
+import { mult } from "./dce-output/Foreign.Test/index.js";
+mult(1)(1);

--- a/test/lib-tests/literals-fromanarray.js
+++ b/test/lib-tests/literals-fromanarray.js
@@ -1,0 +1,4 @@
+import * as lits from "./dce-output/Literals/index.js";
+if (lits.fromAnArray == null || lits.AStr == null || lits.AInt != null) {
+  throw "Error";
+}

--- a/test/lib-tests/literals-fromanobject.js
+++ b/test/lib-tests/literals-fromanobject.js
@@ -1,0 +1,4 @@
+import * as lits from "./dce-output/Literals/index.js";
+if (lits.fromAnObject == null || lits.AStr == null || lits.AInt != null) {
+  throw "Error";
+}

--- a/test/lib-tests/package.json
+++ b/test/lib-tests/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tests",
+  "main": "",
+  "type": "module",
+  "author": "",
+  "license": "MIT"
+}

--- a/test/lib-tests/src/Foreign.js
+++ b/test/lib-tests/src/Foreign.js
@@ -1,19 +1,19 @@
-function add (x, y) {
-    return x + y;
+function add_foreign(x, y) {
+  return x + y;
 }
 
-function mult (x, y) {
-    return x * y;
+function mult_foreign(x, y) {
+  return x * y;
 }
 
-exports.add = function(x) {
-    return function (y) {
-        return add (x, y);
-    }
+export function add(x) {
+  return function (y) {
+    return add_foreign(x, y);
+  };
 }
 
-exports.mult = function(x) {
-    return function (y) {
-        return mult(x, y);
-    }
+export function mult(x) {
+  return function (y) {
+    return mult_foreign(x, y);
+  };
 }

--- a/test/lib-tests/unsafe-coerce-test-unsafex.js
+++ b/test/lib-tests/unsafe-coerce-test-unsafex.js
@@ -1,0 +1,2 @@
+import { unsafeX } from "./dce-output/Unsafe.Coerce.Test/index.js";
+unsafeX(1)(1);

--- a/test/lib-tests/use-reexports.js
+++ b/test/lib-tests/use-reexports.js
@@ -1,0 +1,1 @@
+import { map } from "./dce-output/Control.Alt/index.js";

--- a/zephyr.cabal
+++ b/zephyr.cabal
@@ -75,7 +75,7 @@ library
     , formatting
     , language-javascript >=0.7.0    && <0.8
     , mtl                 >=2.1.0    && <2.3.0
-    , purescript          ^>=0.14.0
+    , purescript          ^>=0.15.0
     , purescript-cst
     , safe                ^>=0.3.9
     , text
@@ -121,8 +121,8 @@ executable zephyr
     , Glob                 >=0.9      && <0.11
     , language-javascript
     , mtl                  >=2.1.0    && <2.3.0
-    , optparse-applicative >=0.13.0   && <0.16
-    , purescript           ^>=0.14.0
+    , optparse-applicative ==0.16.1.0
+    , purescript           ^>=0.15.0
     , purescript-cst
     , text
     , transformers         >=0.3.0    && <0.6
@@ -160,9 +160,9 @@ test-suite zephyr-test
     , HUnit
     , language-javascript
     , mtl                  >=2.1.0    && <2.3.0
-    , optparse-applicative >=0.13.0   && <0.16
+    , optparse-applicative ==0.16.1.0
     , process
-    , purescript           ^>=0.14
+    , purescript           ^>=0.15
     , purescript-cst
     , QuickCheck           >=2.12.1
     , text
@@ -192,4 +192,4 @@ test-suite zephyr-test
 
 source-repository head
   type:     git
-  location: https://github.com/coot/zephyr
+  location: https://github.com/working-group-purescript-es/zephyr


### PR DESCRIPTION
I tried to integrate kl0tl's changes from [here](https://github.com/kl0tl/zephyr/commit/222dd972a325e4d20db7b8a629a2a2ce650611a8)


When I try this build of zephyr on my nextjs project I get the following error:

```
zephyr: An internal error occurred during compilation: Missing value in mnLookup
Please report this at https://github.com/purescript/purescript/issues
CallStack (from HasCallStack):
  error, called at src/Language/PureScript/Crash.hs:23:3 in prscrpt-cst-0.4.0.0-cbfc453d:Language.PureScript.Crash
  internalError, called at src/Language/PureScript/CodeGen/JS.hs:144:35 in prscrpt-0.15.0-40c71a05:Language.PureScript.CodeGen.JS
  ```