### PR TITLE
Run DCE on module re-exports

### DIFF
--- a/src/Language/PureScript/DCE/CoreFn.hs
+++ b/src/Language/PureScript/DCE/CoreFn.hs
@@ -11,6 +11,7 @@ import Control.Monad ( guard )
 import Data.Graph ( graphFromEdges, reachable, Vertex )
 import           Data.Foldable (foldl', foldr')
 import           Data.List (groupBy, sortBy)
+import qualified Data.Map.Strict as M
 import           Data.Maybe (catMaybes, mapMaybe)
 import qualified Data.Set as S
 import Language.PureScript.CoreFn
@@ -22,7 +23,7 @@ import Language.PureScript.CoreFn
       CaseAlternative(CaseAlternative),
       Expr(..),
       Module(Module, moduleImports, moduleExports, moduleForeign,
-             moduleDecls, moduleName) )
+             moduleDecls, moduleName, moduleReExports) )
 import           Language.PureScript.DCE.Utils (bindIdents, unBind)
 import Language.PureScript.Names
     ( getQual,
@@ -39,6 +40,8 @@ type Key = Qualified Ident
 data DCEVertex
   = BindVertex (Bind Ann)
   | ForeignVertex (Qualified Ident)
+  | ReExportedVertex (Qualified Ident)
+  deriving (Show)
 
 
 -- | Dead code elimination of a list of modules module
@@ -61,6 +64,7 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
       -> Module Ann
     runModuleDeadCodeElimination vs mod@Module{ moduleDecls
                         , moduleExports
+                        , moduleReExports
                         , moduleImports
                         , moduleName
                         , moduleForeign
@@ -87,6 +91,17 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
           moduleExports' =
             filter (`elem` (idents ++ moduleForeign')) moduleExports
 
+          moduleReExports' :: M.Map ModuleName [Ident]
+          moduleReExports' =
+            filter (`elem` rexpIdents) <$> moduleReExports
+            where
+              toRexpIdents :: (DCEVertex, Key, [Key]) -> [Ident]
+              toRexpIdents (ReExportedVertex (Qualified _ i), _, _) = [i]
+              toRexpIdents _ = []
+
+              rexpIdents :: [Ident]
+              rexpIdents = concatMap toRexpIdents vs
+
           mods :: [ModuleName]
           mods = mapMaybe getQual (concatMap (\(_, _, ks) -> ks) vs)
 
@@ -104,6 +119,7 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
 
       in mod { moduleImports = moduleImports'
              , moduleExports = moduleExports'
+             , moduleReExports = moduleReExports'
              , moduleForeign = moduleForeign'
              , moduleDecls   = moduleDecls'
              }
@@ -113,9 +129,10 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
     -- | The Vertex set.
     verts :: [(DCEVertex, Key, [Key])]
     verts = do
-        Module _ _ mn _ _ _ _ mf ds <- modules
-        concatMap (toVertices mn) ds
-          ++ ((\q -> (ForeignVertex q, q, [])) . flip mkQualified mn) `map` mf
+        Module _ _ mn _ _ _ rexp mf ds <- modules
+        concatMap (toVertices mn) ds -- Module local bindings
+          ++ ((\q -> (ForeignVertex q, q, [])) . flip mkQualified mn) `map` mf -- Foreign bindings
+          ++ reExportedVertices mn rexp -- Re-exported bindings
       where
       toVertices :: ModuleName -> Bind Ann -> [(DCEVertex, Key, [Key])]
       toVertices mn b@(NonRec _ i e) =
@@ -124,6 +141,23 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
         let ks :: [(Key, [Key])]
             ks = map (\((_, i), e) -> (mkQualified i mn, deps e)) bs
         in map (\(k, ks') -> (BindVertex b, k, map fst ks ++ ks')) ks
+
+      reExportedVertices :: ModuleName -> M.Map ModuleName [Ident] -> [(DCEVertex, Key, [Key])]
+      reExportedVertices parent rexp =
+        filter (isReExported rexp) modules >>= rexpsFor
+        where
+          rexpsFor :: Module Ann -> [(DCEVertex, Key, [Key])]
+          rexpsFor (Module _ _ mn _ _ _ _ _ _) = case M.lookup mn rexp of
+            Nothing -> []
+            Just ids -> (\i -> (ReExportedVertex (mkQualified i parent)
+                              , mkQualified i parent
+                              , [mkQualified i mn])
+                       ) <$> ids
+
+
+      isReExported :: M.Map ModuleName [Ident] -> Module Ann -> Bool
+      isReExported rexps (Module _ _ name _ _ _ _ _ _) =
+        M.member name rexps
 
       -- | Find dependencies of an expression.
       deps :: Expr Ann -> [Key]

--- a/test/Test/Lib.hs
+++ b/test/Test/Lib.hs
@@ -69,6 +69,10 @@ libTests =
             Nothing
             "literals-fromanobject.js"
             True
+  , LibTest ["Control.Alt.map"]
+            Nothing
+            "use-reexports.js"
+            True
   ]
 
 

--- a/test/lib-tests/use-reexports.js
+++ b/test/lib-tests/use-reexports.js
@@ -1,0 +1,1 @@
+import { map } from "./dce-output/Control.Alt/index.js";


### PR DESCRIPTION
Purs 0.14 series added a `moduleReExports` field to the Module type which was initially left intact. This caused a problem when
re-exported names were eliminated in the code but left in the re-export list. This commit eliminates symbols from the re-export list too and adds a test.