### PR TITLE
Fix traversal of CoreFn CaseAlternative Binders

### DIFF
--- a/src/Language/PureScript/DCE/CoreFn.hs
+++ b/src/Language/PureScript/DCE/CoreFn.hs
@@ -169,11 +169,23 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
           onBind (Rec es) = concatMap (traverseExpr . snd) es
 
           onBinder :: Binder Ann -> [Key]
-          onBinder (LiteralBinder _ l) = concatMap onBinder (extractLiteral l)
-          onBinder (ConstructorBinder _ _ c _) =
-            [Ident . runProperName <$> c]
-          onBinder (NamedBinder _ _ b1) = onBinder b1
-          onBinder _ = []
+          onBinder b@(LiteralBinder _ l) =
+            foldl'
+              (++)
+              (onBinder' b)
+              (map onBinder (extractLiteral l))
+          onBinder b@(ConstructorBinder _ _ _ bs) =
+            foldl'
+              (++)
+              (onBinder' b)
+              (map onBinder bs)
+          onBinder b@(NamedBinder _ _ b1) = onBinder' b ++ onBinder b1
+          onBinder b = onBinder' b
+
+          onBinder' :: Binder Ann -> [Key]
+          onBinder' (ConstructorBinder _ _ c _) =
+            [fmap (Ident . runProperName) c]
+          onBinder' _ = []
 
           onCaseAlternative :: CaseAlternative Ann -> [Key]
           onCaseAlternative (CaseAlternative bs (Right val)) =
@@ -186,7 +198,7 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
                          (\(grd, val) ->
                             [traverseExpr grd, traverseExpr val]) gs)
 
-          -- @f@ is either 'Exrp' or 'Binder'
+          -- @f@ is either 'Expr' or 'Binder'
           extractLiteral :: Literal (f Ann) -> [f Ann]
           extractLiteral (ArrayLiteral xs) = xs
           extractLiteral (ObjectLiteral xs) = map snd xs

--- a/test/Test/Lib.hs
+++ b/test/Test/Lib.hs
@@ -69,6 +69,10 @@ libTests =
             Nothing
             "literals-fromanobject.js"
             True
+  , LibTest ["Data.Array.span"]
+            Nothing
+            "das-test.js"
+            True
   ]
 
 

--- a/test/lib-tests/das-test.js
+++ b/test/lib-tests/das-test.js
@@ -1,0 +1,6 @@
+import { span } from "./dce-output/Data.Array/index.js";
+
+const res = span((n) => n % 2 == 1)([1, 3, 2, 4, 5]);
+if (res.init.includes(2) || res.init.includes(4) || res.init.includes(5)) {
+  throw "Error";
+}


### PR DESCRIPTION
Commit 5734b103c re-implemented the Purescript `everythingOnValues` function locally. While simplifying the function for the specific use-case vital functionality was left out for traversing `CaseAlternatives`. This commit re-introduces the removed functionality and adds a regression test.